### PR TITLE
Pmd version parameter or default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-alpine
 
-ENV PMD_VERSION 6.14.0
+ARG PMD_VERSION=${PMD_VERSION:-6.14.0}
 
 RUN apk add --update --no-cache wget unzip
 RUN mkdir -p /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-alpine
 
-ARG PMD_VERSION=${PMD_VERSION:-6.14.0}
+ARG PMD_VERSION=${PMD_VERSION:-6.26.0}
 
 RUN apk add --update --no-cache wget unzip
 RUN mkdir -p /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-alpine
 
-ARG PMD_VERSION=${PMD_VERSION:-6.26.0}
+ARG PMD_VERSION=${PMD_VERSION:-6.30.0}
 
 RUN apk add --update --no-cache wget unzip
 RUN mkdir -p /opt

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ ex: Apex analysis with builtin rulesets
 
   - `/src/` - default working directory
 
-#### Environment Variables
+#### Build Args
 
-  - `PMD_VERSION` - PMD version used to build this image
+  - `PMD_VERSION` - PMD version used to build this image. If omitted, the hardcoded version in the Dockerfile will be downloaded.
 
 ## Contributing
 


### PR DESCRIPTION
Hello @rody 

I've improved your project and I'd like you to merge it.

The `PMD_VERSION` was hardcoded, so it wasn't possible to build an image with a different version without touching the `Dockerfile`. Now it's possible. I manage a private GitLab instance with Docker Registry and now the image build works like a charm!

I've also updated the default `PMD_VERSION` to the latest ;-)