### PR TITLE
fix: remove workdir instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,5 @@ RUN cd /opt \
 
 RUN apk add --update --no-cache dumb-init
 
-RUN mkdir /src
-VOLUME /src
-WORKDIR /src
-
 ENTRYPOINT [ "/usr/bin/dumb-init", "/usr/bin/java", "-classpath", "/opt/pmd/lib/*", "net.sourceforge.pmd.PMD" ]
 CMD ""


### PR DESCRIPTION
since -dir is a mandatory argument for PMD, it does not
make sense to create a default workir.
This also enables the image to be used in Github actions
where setting up a workdir is discouraged.